### PR TITLE
Refact links

### DIFF
--- a/src/collection/aws-vault.py
+++ b/src/collection/aws-vault.py
@@ -14,5 +14,5 @@ class AwsVault(Package):
     if sys.platform == 'linux':
         asset_pattern = r'aws-vault-linux-amd64'
 
-    bin_name = 'aws-vault'
-    bin_pattern = './aws-vault-*'
+    bin_pattern = ['./aws-vault-*']
+    link_pattern = {'./aws-vault-*': '$BIN_DIR/aws-vault'}

--- a/src/collection/awscli.py
+++ b/src/collection/awscli.py
@@ -12,6 +12,7 @@ class AwsCli(Package):
     source = PackageSource.GITHUB_TAG
 
     bin_pattern = ['./aws/dist/aws', './aws/dist/aws_completer']
+    link_pattern = {'./aws/dist/aws': '$BIN_DIR/aws', './aws/dist/aws_completer': '$BIN_DIR/aws_completer'}
 
     async def download_url(self) -> str:
         if sys.platform != 'linux':

--- a/src/collection/delta.py
+++ b/src/collection/delta.py
@@ -19,4 +19,5 @@ class Delta(Package):
     elif sys.platform == 'darwin':
         asset_pattern = r'.*darwin\.tar\.gz'
 
-    bin_pattern = './**/delta'
+    bin_pattern = ['./*/delta']
+    link_pattern = {'./*/delta': '$BIN_DIR/delta'}

--- a/src/collection/fonts/firamono.py
+++ b/src/collection/fonts/firamono.py
@@ -1,10 +1,5 @@
-import os
-
-from aiopath import AsyncPath
-
 from package import Package
 from package.source import PackageSource
-from utils.glob import create_symlink_base
 
 
 class FiraMono(Package):
@@ -14,19 +9,13 @@ class FiraMono(Package):
     repo = 'ryanoasis/nerd-fonts'
     source = PackageSource.GITHUB_RELEASE
 
+    link_pattern = {
+        './Fira Mono Bold Nerd Font Complete Mono.otf':
+        '~/.local/share/fonts/FiraMono/Fira Mono Bold Nerd Font Complete Mono.otf',
+        './Fira Mono Medium Nerd Font Complete Mono.otf':
+        '~/.local/share/fonts/FiraMono/Fira Mono Medium Nerd Font Complete Mono.otf',
+        './Fira Mono Regular Nerd Font Complete Mono.otf':
+        '~/.local/share/fonts/FiraMono/Fira Mono Regular Nerd Font Complete Mono.otf'
+    }
+
     asset_pattern = r'FiraMono\.zip'
-
-    async def postinstall(self):
-        allow_list = [
-            'Fira Mono Bold Nerd Font Complete Mono.otf',
-            'Fira Mono Medium Nerd Font Complete Mono.otf',
-            'Fira Mono Regular Nerd Font Complete Mono.otf',
-        ]
-
-        home_font_dir = os.path.join(os.path.expanduser('~'), '.local/share/fonts/FiraMono')
-        await AsyncPath(home_font_dir).mkdir(parents=True, exist_ok=True)
-
-        for file_name in allow_list:
-            file_dir = os.path.join(self.package_out_dir, file_name)
-            home_file_dir = os.path.join(home_font_dir, file_name)
-            await create_symlink_base(target=file_dir, dest=home_file_dir)

--- a/src/collection/fonts/firamono.py
+++ b/src/collection/fonts/firamono.py
@@ -8,6 +8,7 @@ class FiraMono(Package):
 
     repo = 'ryanoasis/nerd-fonts'
     source = PackageSource.GITHUB_RELEASE
+    asset_pattern = r'FiraMono\.zip'
 
     link_pattern = {
         './Fira Mono Bold Nerd Font Complete Mono.otf':
@@ -17,5 +18,3 @@ class FiraMono(Package):
         './Fira Mono Regular Nerd Font Complete Mono.otf':
         '~/.local/share/fonts/FiraMono/Fira Mono Regular Nerd Font Complete Mono.otf'
     }
-
-    asset_pattern = r'FiraMono\.zip'

--- a/src/collection/fonts/pretendard.py
+++ b/src/collection/fonts/pretendard.py
@@ -1,10 +1,5 @@
-import os
-
-from aiopath import AsyncPath
-
 from package import Package
 from package.source import PackageSource
-from utils.glob import create_symlink_base
 
 
 class Pretendard(Package):
@@ -13,12 +8,6 @@ class Pretendard(Package):
 
     repo = 'orioncactus/pretendard'
     source = PackageSource.GITHUB_RELEASE
-
     asset_pattern = r'Pretendard-.*\.zip'
 
-    async def postinstall(self):
-        bin_font_dir = os.path.join(self.package_out_dir, 'public', 'static')
-        home_font_dir = AsyncPath(os.path.expanduser('~'), '.local/share/fonts/Pretendard')
-        await home_font_dir.parent.mkdir(parents=True, exist_ok=True)
-
-        await create_symlink_base(target=bin_font_dir, dest=home_font_dir)
+    link_pattern = {'./public/static': '~/.local/share/fonts/Pretendard'}

--- a/src/collection/gh.py
+++ b/src/collection/gh.py
@@ -19,4 +19,5 @@ class Gh(Package):
     elif sys.platform == 'darwin':
         asset_pattern = r'.*macOS_amd64\.tar\.gz'
 
-    bin_pattern = './**/bin/gh'
+    bin_pattern = ['./*/bin/gh']
+    link_pattern = {'./*/bin/gh': '$BIN_DIR/gh'}

--- a/src/collection/hadolint.py
+++ b/src/collection/hadolint.py
@@ -16,5 +16,5 @@ class Hadolint(Package):
     elif sys.platform == 'darwin':
         asset_pattern = r'.*Darwin.*'
 
-    bin_name = 'hadolint'
-    bin_pattern = './hadolint-*'
+    bin_pattern = ['./hadolint-*']
+    link_pattern = {'./hadolint-*': "$BIN_DIR/hadolint"}

--- a/src/collection/kubectl.py
+++ b/src/collection/kubectl.py
@@ -12,7 +12,8 @@ class Kubectl(Package):
     repo = 'kubernetes/kubernetes'
     source = PackageSource.GITHUB_RELEASE
 
-    bin_pattern = './kubectl'
+    bin_pattern = ['./kubectl']
+    link_pattern = {'./kubectl': '$BIN_DIR/kubectl'}
 
     async def download_url(self) -> str:
         arch = 'amd64' if hardware.is_x86_64 else '386'

--- a/src/collection/ll.py
+++ b/src/collection/ll.py
@@ -16,4 +16,5 @@ class Ll(Package):
     elif sys.platform == 'darwin':
         asset_pattern = r'.*macos.*'
 
-    bin_pattern = './ll'
+    bin_pattern = ['./ll']
+    link_pattern = {'./ll': '$BIN_DIR/ll'}

--- a/src/collection/lokalise2.py
+++ b/src/collection/lokalise2.py
@@ -19,4 +19,5 @@ class Lokalise2(Package):
     elif sys.platform == 'darwin':
         asset_pattern = r'.*darwin.*'
 
-    bin_pattern = './lokalise2'
+    bin_pattern = ['./lokalise2']
+    link_pattern = {'./lokalise2': '$BIN_DIR/lokalise2'}

--- a/src/collection/minikube.py
+++ b/src/collection/minikube.py
@@ -12,8 +12,8 @@ class Minikube(Package):
     repo = 'kubernetes/minikube'
     source = PackageSource.GITHUB_RELEASE
 
-    bin_name = 'minikube'
-    bin_pattern = './minikube-*'
+    bin_pattern = ['./minikube-*']
+    link_pattern = {'./minikube-*': '$BIN_DIR/minikube'}
 
     async def download_url(self) -> str:
         arch = 'amd64' if hardware.is_x86_64 else '386'

--- a/src/collection/pipenv.py
+++ b/src/collection/pipenv.py
@@ -5,8 +5,6 @@ from aiopath import AsyncPath
 
 from package import Package
 from package.source import PackageSource
-from utils.configs import BIN_DIR
-from utils.glob import create_symlink_base
 
 
 class Pipenv(Package):
@@ -16,20 +14,19 @@ class Pipenv(Package):
     repo = 'pypa/pipenv'
     source = PackageSource.GITHUB_TAG
 
-    async def postinstall(self):
-        # Consider top directory
+    bin_pattern = ['./*/.venv/bin/pipenv']
+    link_pattern = {'./*/.venv/bin/pipenv': '$BIN_DIR/pipenv'}
+
+    async def preinstall(self):
+        # Use top directory
         pipenv_dirs = [path async for path in AsyncPath(self.package_out_dir).iterdir() if await path.is_dir()]
 
         if len(pipenv_dirs) != 1:
             raise ValueError(f'Pipenv has multiple root folders! ({len(pipenv_dirs)})')
 
-        pipenv_dir = str(pipenv_dirs[0]).strip()
-
+        pipenv_dir = str(pipenv_dirs[0])
         venv_dir = os.path.join(pipenv_dir, '.venv')
         venv_pip_dir = os.path.join(venv_dir, 'bin', 'pip')
-
-        bin_pipenv_dir = os.path.join(venv_dir, 'bin', 'pipenv')
-        home_pipenv_dir = os.path.join(BIN_DIR, 'pipenv')
 
         proc = await asyncio.create_subprocess_shell(
             f'/usr/bin/python3 -m venv {venv_dir} && {venv_pip_dir} install -q {pipenv_dir}',
@@ -37,6 +34,3 @@ class Pipenv(Package):
             stderr=asyncio.subprocess.PIPE)
 
         await proc.wait()
-
-        # Post create ./.venv/bin/pipenv
-        await create_symlink_base(target=bin_pipenv_dir, dest=home_pipenv_dir, is_executable=True)

--- a/src/collection/theme/apple-cursor.py
+++ b/src/collection/theme/apple-cursor.py
@@ -1,10 +1,5 @@
-import os
-
-from aiopath import AsyncPath
-
 from package import Package
 from package.source import PackageSource
-from utils.glob import create_symlink_base
 
 
 class AppleCursor(Package):
@@ -13,13 +8,6 @@ class AppleCursor(Package):
 
     repo = 'ful1e5/apple_cursor'
     source = PackageSource.GITHUB_RELEASE
-
     asset_pattern = r'.*macOSBigSur.tar.gz'
 
-    async def postinstall(self):
-        theme_dir = AsyncPath(self.package_out_dir, 'macOSBigSur')
-
-        home_theme_dir = AsyncPath(os.path.expanduser('~'), '.icons/apple-cursor')
-        await home_theme_dir.parent.mkdir(parents=True, exist_ok=True)
-
-        await create_symlink_base(target=theme_dir, dest=home_theme_dir)
+    link_pattern = {'./macOSBigSur': '~/.icons/apple-cursor'}

--- a/src/collection/theme/la-capitaine-icon-theme.py
+++ b/src/collection/theme/la-capitaine-icon-theme.py
@@ -1,10 +1,5 @@
-import os
-
-from aiopath import AsyncPath
-
 from package import Package
 from package.source import PackageSource
-from utils.glob import create_symlink_base
 
 
 class LaCapitaineIconTheme(Package):
@@ -14,16 +9,4 @@ class LaCapitaineIconTheme(Package):
     repo = 'keeferrourke/la-capitaine-icon-theme'
     source = PackageSource.GITHUB_TAG
 
-    async def postinstall(self):
-        # Consider top directory
-        theme_dirs = [path async for path in AsyncPath(self.package_out_dir).iterdir() if await path.is_dir()]
-
-        if len(theme_dirs) != 1:
-            raise ValueError(f'LaCapitaineIconTheme has multiple root folders! ({len(theme_dirs)})')
-
-        theme_dir = str(theme_dirs[0]).strip()
-
-        home_theme_dir = AsyncPath(os.path.expanduser('~'), '.local/share/icons/la-capitaine-icon-theme')
-        await home_theme_dir.parent.mkdir(parents=True, exist_ok=True)
-
-        await create_symlink_base(target=theme_dir, dest=home_theme_dir)
+    link_pattern = {'./*': '~/.local/share/icons/la-capitaine-icon-theme'}

--- a/src/collection/yarn.py
+++ b/src/collection/yarn.py
@@ -8,6 +8,7 @@ class Yarn(Package):
 
     repo = 'yarnpkg/yarn'
     source = PackageSource.GITHUB_RELEASE
-
     asset_pattern = r'.*\.tar\.gz$'
-    bin_pattern = './**/bin/yarn'
+
+    bin_pattern = ['./*/bin/yarn']
+    link_pattern = {'./*/bin/yarn': '$BIN_DIR/yarn'}

--- a/src/console/message.py
+++ b/src/console/message.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Dict, Optional
 
 import rich
 from rich.progress import ProgressBar
@@ -54,11 +54,11 @@ def get_package_install(name: str, prev_version: Optional[str], next_version: Op
     return f'\n{indent(2)}[{dot_color}]•[/{dot_color}] {_package_status()} [cyan]{name}[/cyan] {versions}'
 
 
-def get_package_install_file(file_patterns: List[str]) -> str:
-    if not file_patterns:
-        return f'{indent(6)}[yellow]Warning: You did not specify bin pattern to install![/yellow]'
+def get_package_install_file(link_pattern: Dict[str, str]) -> str:
+    if not link_pattern:
+        return f'{indent(6)}[yellow]Warning: You did not specify any pattern to link![/yellow]'
 
-    return f'{indent(6)}Installing {", ".join(file_patterns)}'
+    return f'{indent(6)}Installing {", ".join(link_pattern.keys())}'
 
 
 def get_package_download(file_name: str, file_size: Optional[int]) -> str:

--- a/src/lock/__init__.py
+++ b/src/lock/__init__.py
@@ -56,10 +56,5 @@ class PackageLock(object):
         raw_content = {**(self.lock_content or {}), **kwargs}
         lock_content = OrderedDict(sorted(raw_content.items(), key=lambda item: item[0]))
 
-        async with self.lock_file.open(mode='wb') as file:
-            file: AsyncFile
-
-            raw_data = json.dumps(lock_content, indent=2).encode()
-            await file.write(raw_data)
-
+        await self.lock_file.write_text(json.dumps(lock_content, indent=2))
         self.lock_content = lock_content

--- a/src/lock/__init__.py
+++ b/src/lock/__init__.py
@@ -14,7 +14,7 @@ class PackageLock(object):
 
     Attributes:
         package_name: Package's name
-        lock_content: Lock file's content (key: name, version, bins, ...)
+        lock_content: Lock file's content (key: name, version, files, ...)
     """
 
     package_name: str

--- a/src/lock/__init__.py
+++ b/src/lock/__init__.py
@@ -56,7 +56,7 @@ class PackageLock(object):
         raw_content = {**(self.lock_content or {}), **kwargs}
         lock_content = OrderedDict(sorted(raw_content.items(), key=lambda item: item[0]))
 
-        async with self.lock_file.open(mode='wb', encoding=None, errors=None, newline=None) as file:
+        async with self.lock_file.open(mode='wb') as file:
             file: AsyncFile
 
             raw_data = json.dumps(lock_content, indent=2).encode()

--- a/src/package/base.py
+++ b/src/package/base.py
@@ -130,9 +130,7 @@ class Package(object):
                     chunks += chunk
                     dynamic.update_message(message.get_package_download_progress(content_length, len(chunks)))
 
-                async with AsyncPath(download_file_dir).open(mode='wb') as file:
-                    file: AsyncFile
-                    await file.write(chunks)
+                await AsyncPath(download_file_dir).write_bytes(chunks)
 
                 dynamic.update_message(message.get_package_download_progress(finish=True))
 

--- a/src/package/base.py
+++ b/src/package/base.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from aiopath import AsyncPath
 from anyio import AsyncFile
@@ -15,7 +15,7 @@ from utils.archive import unarchive_file
 from utils.configs import INSTALL_DIR
 from utils.formatters import format_download_filename
 from utils.request import request
-from utils.symlink import create_symlink
+from utils.symlink import create_symlink, make_executable
 
 
 class Package(object):
@@ -30,6 +30,7 @@ class Package(object):
         source: Package source type
         asset_pattern: Asset searching from release, regex pattern (github release)
 
+        bin_pattern: Bin files to make executable
         link_pattern: Link from unarhived outputs to specific paths
 
         _lock: Package lock instance
@@ -44,6 +45,7 @@ class Package(object):
     source: PackageSource = PackageSource.NONE
     asset_pattern: Optional[str] = None
 
+    bin_pattern: List[str] = []
     link_pattern: Dict[str, str] = {}
 
     _lock: PackageLock
@@ -138,6 +140,7 @@ class Package(object):
             await unarchive_file(download_file_dir, self.package_out_dir)
             # TODO(sudosubin): Remove previous installed symlinks, read from lock file
             await create_symlink(self.package_out_dir, self.link_pattern)
+            await make_executable(self.package_out_dir, self.bin_pattern)
 
             # Postinstall hook
             await self.postinstall()

--- a/src/package/base.py
+++ b/src/package/base.py
@@ -28,10 +28,9 @@ class Package(object):
 
         repo: Package vcs repository name
         source: Package source type
+        asset_pattern: Asset searching from release, regex pattern (github release)
 
         link_pattern: Link from unarhived outputs to specific paths
-
-        asset_pattern: Asset searching from release, regex pattern (github release)
 
         _lock: Package lock instance
         _source: Package source instance
@@ -43,10 +42,9 @@ class Package(object):
 
     repo: Optional[str] = None
     source: PackageSource = PackageSource.NONE
+    asset_pattern: Optional[str] = None
 
     link_pattern: Dict[str, str] = {}
-
-    asset_pattern: Optional[str] = None
 
     _lock: PackageLock
     _source: BasePackageSource

--- a/src/package/base.py
+++ b/src/package/base.py
@@ -127,8 +127,7 @@ class Package(object):
                     chunks += chunk
                     dynamic.update_message(message.get_package_download_progress(content_length, len(chunks)))
 
-                async with AsyncPath(download_file_dir).open(mode='wb', encoding=None, errors=None,
-                                                             newline=None) as file:
+                async with AsyncPath(download_file_dir).open(mode='wb') as file:
                     file: AsyncFile
                     await file.write(chunks)
 

--- a/src/package/base.py
+++ b/src/package/base.py
@@ -105,6 +105,9 @@ class Package(object):
         prev_version = await self.installed_version()
         next_version = await self.planned_version()
 
+        # Predownload hook
+        await self.predownload()
+
         def _get_heading(finish: bool = False):
             return message.get_package_install(self.name, prev_version, next_version, finish=finish)
 
@@ -133,10 +136,17 @@ class Package(object):
 
                 dynamic.update_message(message.get_package_download_progress(finish=True))
 
+            # Postdownload hook
+            await self.postdownload()
+
             dynamic.add_message(message.get_package_install_file(self.link_pattern))
 
             # Extract and install with glob pattern
             await unarchive_file(download_file_dir, self.package_out_dir)
+
+            # Preinstall hook
+            await self.preinstall()
+
             # TODO(sudosubin): Remove previous installed symlinks, read from lock file
             await create_symlink(self.package_out_dir, self.link_pattern)
             await make_executable(self.package_out_dir, self.bin_pattern)
@@ -149,8 +159,16 @@ class Package(object):
 
             dynamic.update_heading(_get_heading(finish=True))
 
+    async def predownload(self):
+        pass
+
+    async def postdownload(self):
+        pass
+
+    async def preinstall(self):
+        pass
+
     async def postinstall(self):
-        """Implemented from each collection, onlt if needed"""
         pass
 
     @classmethod

--- a/src/utils/glob.py
+++ b/src/utils/glob.py
@@ -1,9 +1,0 @@
-import os
-import stat
-from pathlib import Path
-from typing import Union
-
-
-async def make_executable(path: Union[str, Path]):
-    st = os.stat(path)
-    os.chmod(path, st.st_mode | stat.S_IEXEC)

--- a/src/utils/glob.py
+++ b/src/utils/glob.py
@@ -1,47 +1,9 @@
 import os
 import stat
 from pathlib import Path
-from typing import List, Optional, Union
-
-from aiopath import AsyncPath
-
-from utils.configs import BIN_DIR
+from typing import Union
 
 
 async def make_executable(path: Union[str, Path]):
     st = os.stat(path)
     os.chmod(path, st.st_mode | stat.S_IEXEC)
-
-
-async def create_symlink_base(target: Union[str, Path], dest: Union[str, Path], is_executable: bool = False):
-    dest_dir = AsyncPath(dest)
-    target_is_directory = await AsyncPath(target).is_dir()
-
-    if is_executable and not target_is_directory:
-        await make_executable(target)
-
-    await dest_dir.unlink(missing_ok=True)
-    await dest_dir.symlink_to(target, target_is_directory=target_is_directory)
-
-
-async def create_symlink(src_dir: Union[str, Path], glob_patterns: List[str], symlink_name: Optional[str]):
-    symlink_paths: List[Path] = [path for glob_pattern in glob_patterns for path in Path(src_dir).glob(glob_pattern)]
-
-    dest_paths: List[str] = []
-
-    if glob_patterns and len(symlink_paths) == 0:
-        raise ValueError('No symlink paths were found!')
-
-    # If symlink_name is specified, only one symlink available
-    if symlink_name is not None and len(symlink_paths) > 1:
-        raise ValueError('Only one symlink is available when symlink name is specified!')
-
-    await AsyncPath(BIN_DIR).mkdir(parents=True, exist_ok=True)
-
-    for target in symlink_paths:
-        dest = os.path.join(BIN_DIR, symlink_name or target.name)
-        dest_paths.append(dest)
-
-        await create_symlink_base(target=target, dest=dest, is_executable=True)
-
-    return dest_paths

--- a/src/utils/symlink.py
+++ b/src/utils/symlink.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple, Union
+
+from aiopath import AsyncPath
+
+
+async def create_symlink(src_dir: Union[str, Path], link_pattern: Dict[str, str]):
+    symlink_pattern: List[Tuple[AsyncPath, AsyncPath]] = []
+
+    # Translate link_pattern to symlink_pattern
+    for key, value in link_pattern.items():
+        key_candidates: List[AsyncPath] = [path async for path in AsyncPath(src_dir).glob(key)]
+
+        if len(key_candidates) != 1:
+            raise ValueError('Multiple src file found during linking files!')
+
+        symlink_key = key_candidates[0]
+        symlink_value = AsyncPath(os.path.expanduser(value))
+
+        symlink_pattern.append((symlink_key, symlink_value))
+
+    # Link files
+    for src_path, dest_path in symlink_pattern:
+        await dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        is_directory = await src_path.is_dir()
+
+        await dest_path.unlink(missing_ok=True)
+        await dest_path.symlink_to(src_path, target_is_directory=is_directory)

--- a/src/utils/symlink.py
+++ b/src/utils/symlink.py
@@ -1,8 +1,28 @@
 import os
+import stat
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
 from aiopath import AsyncPath
+
+from utils.configs import BIN_DIR
+
+
+async def get_symlink_path(src_dir: Union[str, Path], pattern: str) -> AsyncPath:
+    candidates: List[AsyncPath] = [path async for path in AsyncPath(src_dir).glob(pattern)]
+
+    if len(candidates) != 1:
+        raise ValueError('Multiple src file found during linking files!')
+
+    return candidates[0]
+
+
+async def make_executable(src_dir: Union[str, Path], bin_pattern: List[str]):
+
+    for path in bin_pattern:
+        symlink_path = await get_symlink_path(src_dir, path)
+        st = os.stat(symlink_path)
+        os.chmod(symlink_path, st.st_mode | stat.S_IEXEC)
 
 
 async def create_symlink(src_dir: Union[str, Path], link_pattern: Dict[str, str]):
@@ -10,13 +30,8 @@ async def create_symlink(src_dir: Union[str, Path], link_pattern: Dict[str, str]
 
     # Translate link_pattern to symlink_pattern
     for key, value in link_pattern.items():
-        key_candidates: List[AsyncPath] = [path async for path in AsyncPath(src_dir).glob(key)]
-
-        if len(key_candidates) != 1:
-            raise ValueError('Multiple src file found during linking files!')
-
-        symlink_key = key_candidates[0]
-        symlink_value = AsyncPath(os.path.expanduser(value))
+        symlink_key = await get_symlink_path(src_dir, key)
+        symlink_value = AsyncPath(os.path.expanduser(value).replace('$BIN_DIR', BIN_DIR))
 
         symlink_pattern.append((symlink_key, symlink_value))
 


### PR DESCRIPTION
- Refact `Package` class
  - Add `link_pattern` property, which just links files/dirs
  - Change `bin_pattern` property, which just identity for files to make executable
  - Remove `bin_name` property.
- Add more `Package` hooks
  - predownload, postdownload, preinstall, postinstall
- `aiopath` refines
  - Just some refacts for clean, short codes (errors were fixed from `aiopath==0.5.11`)
- Changes were applied to all current packages